### PR TITLE
fix: issue #1 (apt-get install --yes)

### DIFF
--- a/install_cli.sh
+++ b/install_cli.sh
@@ -1,8 +1,8 @@
 # install azure cli on debian-based os
 
-sudo apt-get install ca-certificates curl apt-transport-https lsb-release gnupg
+sudo apt-get install -y ca-certificates curl apt-transport-https lsb-release gnupg
 curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null
 AZ_REPO=$(lsb_release -cs)
 echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
 sudo apt-get update
-sudo apt-get install azure-cli
+sudo apt-get install -y azure-cli


### PR DESCRIPTION
adding configuration option to `apt-get install` commands
-y, --yes, --assume-yes
           Automatic yes to prompts; assume "yes" as answer to all prompts and run
           non-interactively. If an undesirable situation, such as changing a held package,
           trying to install a unauthenticated package or removing an essential package occurs
           then apt-get will abort. Configuration Item: APT::Get::Assume-Yes.